### PR TITLE
Fix ruby 2.2 warning (error) about circular argument reference and add ruby 2.2 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.1
+  - 2.2
   - jruby-19mode
 gemfile:
   - Gemfile

--- a/lib/minitest/matchers_vaccine.rb
+++ b/lib/minitest/matchers_vaccine.rb
@@ -38,7 +38,7 @@ module Minitest
     #     must belong_to :account
     #     must have_many :line_items
     #   end
-    def must(matcher, subject = @subject || subject, msg = nil)
+    def must(matcher, subject = @subject || subject(), msg = nil)
       assert_must matcher, subject, msg
     end
 
@@ -80,7 +80,7 @@ module Minitest
     #   it "should validate" do
     #     wont have_valid(:email).when("foo", "foo@bar", "@bar.com")
     #   end
-    def wont(matcher, subject = @subject || subject, msg = nil)
+    def wont(matcher, subject = @subject || subject(), msg = nil)
       assert_wont matcher, subject, msg
     end
   end

--- a/test/matchers_test.rb
+++ b/test/matchers_test.rb
@@ -89,7 +89,7 @@ describe "#must" do
 
   describe "without a subject" do
     it "should error" do
-      assert_raises(NameError) { must be_instance_of Array }
+      assert_raises(NoMethodError) { must be_instance_of Array }
     end
   end
 end
@@ -125,7 +125,7 @@ describe "#wont" do
 
   describe "without a subject" do
     it "should error" do
-      assert_raises(NameError) { wont be_instance_of Array }
+      assert_raises(NoMethodError) { wont be_instance_of Array }
     end
   end
 end


### PR DESCRIPTION
With Ruby 2.2, minitest-matchers_vaccine is producing the following errors that cause my builds to fail:

...1.02/lib/minitest/matchers_vaccine.rb:41: warning: circular argument reference - subject
...1.0.2/lib/minitest/matchers_vaccine.rb:83: warning: circular argument reference - subject

This fixes that warning the same way as Rails fixed this issue here (and allows my builds to pass):
https://github.com/tmm1/rails/commit/8fd52705eda6a2cd7e9a8a5bc723fa094e359eb7
